### PR TITLE
Implement pluma/MATE support

### DIFF
--- a/installer
+++ b/installer
@@ -6,12 +6,18 @@ usage()
 cat << EOF
 usage: $0 [options]
 
-This script installs the Solarized styles for gedit.
+This script installs the Solarized styles for gedit 3 or pluma (MATE)
 
 OPTIONS:
   -h    Shows this message
+  
+gedit3 (GNOME):
   -a    Install for all users
   -l    Install only for you
+
+pluma (MATE):
+  -A    Install for all users
+  -L    Install only for you
 EOF
 }
 
@@ -56,7 +62,7 @@ do
         ?)
             INSTALLPATH=$HOME/.local/share/gedit/styles
             ;;
-    esac
+    esac # is ridiculous
 done
 
 # install for all users when sudo set to true

--- a/installer
+++ b/installer
@@ -32,7 +32,7 @@ INSTALLPATH=$HOME/.local/share/gedit/styles
 NEEDSUDO=false
 
 # loop through passed arguments
-while getopts "hal" OPTION
+while getopts "halAL" OPTION
 do
     case $OPTION in
         h)
@@ -43,8 +43,15 @@ do
             INSTALLPATH=/usr/share/gtksourceview-3.0/styles
             NEEDSUDO=true
             ;;
+        A)
+            INSTALLPATH=/usr/share/gtksourceview-2.0/styles
+            NEEDSUDO=true
+            ;;
         l)
             INSTALLPATH=$HOME/.local/share/gedit/styles
+            ;;
+        L)
+            INSTALLPATH=$HOME/.config/pluma/styles
             ;;
         ?)
             INSTALLPATH=$HOME/.local/share/gedit/styles


### PR DESCRIPTION
This patch lets the installer work with MATE's text editor, pluma.

It uses the same syntax for the source highlighting as GNOME 3.
